### PR TITLE
Bump ref-napi to 3.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ node_js:
   - "8"
   - "10"
   - "12"
+  - "14"
 
 install:
   - PATH="`npm bin`:`npm bin -g`:$PATH"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ environment:
     - nodejs_version: "8"
     - nodejs_version: "10"
     - nodejs_version: "12"
+    - nodejs_version: "14"
 
 platform:
   - x86

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "array-index": "1",
     "debug": "2",
-    "ref-napi": "^1.4.2"
+    "ref-napi": "^3.0.1"
   },
   "devDependencies": {
     "bindings": "1",


### PR DESCRIPTION
`ref-napi` 3.0.1 works better with modern Node versions and new architectures (like Windows arm64) 🚀 